### PR TITLE
feat: add pre-charged compound to adduct definition

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MetaboCoreUtils
 Title: Core Utils for Metabolomics Data
-Version: 1.1.1
+Version: 1.1.2
 Description: MetaboCoreUtils defines metabolomics-related core functionality
     provided as low-level functions to allow a data structure-independent usage
     across various R packages. This includes functions to calculate between ion
@@ -38,4 +38,4 @@ BugReports: https://github.com/RforMassSpectrometry/MetaboCoreUtils/issues
 URL: https://github.com/RforMassSpectrometry/MetaboCoreUtils
 biocViews: Infrastructure, Metabolomics, MassSpectrometry
 Roxygen: list(markdown=TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # MetaboCoreutils 1.1
 
+## MetaboCoreUtils 1.1.2
+
+- Add already charged adduct/ion to the adduct definition.
+
 ## MetaboCoreUtils 1.1.1
 
 - Add `correctRindex` function.

--- a/inst/adducts/adduct_definition.txt
+++ b/inst/adducts/adduct_definition.txt
@@ -54,3 +54,5 @@
 "[M-H+HCOONa]-"	1	66.980164	"HCOONa"	"H"	-1	FALSE
 "[M+H-H4O2]+"	1	-35.01385294	"H"	"H4O2"	1	TRUE
 "[M+H-CH2O2]+"	1	-44.99820287	"H"	"CH2O2"	1	TRUE
+"[M]+"	1	0	""	""	1	TRUE
+"[M]-"	1	0	""	""	1	FALSE


### PR DESCRIPTION
This adds a `[M]+` and `[M]-` adduct definition to support pre-charged compounds.