### PR TITLE
heavy isotopes support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MetaboCoreUtils
 Title: Core Utils for Metabolomics Data
-Version: 1.3.7
+Version: 1.3.8
 Description: MetaboCoreUtils defines metabolomics-related core functionality
     provided as low-level functions to allow a data structure-independent usage
     across various R packages. This includes functions to calculate between ion

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # MetaboCoreutils 1.3
 
+## MetaboCoreUtils 1.3.8
+
+- Support for heavy isotopes in `countElements`.
+
 ## MetaboCoreUtils 1.3.7
 
 - Fix bug in `containsElements` function (issue

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 ## MetaboCoreUtils 1.3.8
 
-- Support for heavy isotopes in `countElements`.
+- Support for heavy isotopes in `countElements`/`pasteElements`/`calculateMass`
+  (issue [#53](https://github.com/rformassspectrometry/MetaboCoreUtils/issues/53)).
 
 ## MetaboCoreUtils 1.3.7
 

--- a/R/chemFormula.R
+++ b/R/chemFormula.R
@@ -286,6 +286,7 @@ addElements <- function(x, y) {
 #' calculateMass("C6H12O6")
 #' calculateMass("NH3")
 #' calculateMass(c("C6H12O6", "NH3"))
+#' calculateMass(c("C6H12O6", "[13C3]C3H12O6"))
 calculateMass <- function(x) {
     if (is.character(x))
         x <- countElements(x)

--- a/R/chemFormula.R
+++ b/R/chemFormula.R
@@ -23,25 +23,30 @@ countElements <- function(x) {
     ## regex pattern to isolate all elements
     element_pattern <- paste0(
         "(?<Element>",
-            "[A][cglmrstu]|",
-            "[B][aehikr]?|",
-            "[C][adeflmnorsu]?|",
-            "[D][bsy]|",
-            "[E][rsu]|",
-            "[F][elmr]?|",
-            "[G][ade]|",
-            "[H][efgos]?|",
-            "[I][nr]?|",
-            "[K][r]?|",
-            "[L][airuv]|",
-            "[M][cdgnot]|",
-            "[N][abdehiop]?|",
-            "[O][gs]?|",
-            "[P][abdmortu]?|",
-            "[R][abefghnu]|",
-            "[S][bcegimnr]?|",
-            "[T][abcehilms]|",
-            "[U]|[V]|[W]|[X][e]|[Y][b]?|[Z][nr]",
+            paste0("[0-9]*",
+                c(
+                    "[A][cglmrstu]|",
+                    "[B][aehikr]?|",
+                    "[C][adeflmnorsu]?|",
+                    "[D][bsy]|",
+                    "[E][rsu]|",
+                    "[F][elmr]?|",
+                    "[G][ade]|",
+                    "[H][efgos]?|",
+                    "[I][nr]?|",
+                    "[K][r]?|",
+                    "[L][airuv]|",
+                    "[M][cdgnot]|",
+                    "[N][abdehiop]?|",
+                    "[O][gs]?|",
+                    "[P][abdmortu]?|",
+                    "[R][abefghnu]|",
+                    "[S][bcegimnr]?|",
+                    "[T][abcehilms]|",
+                    "[U]|[V]|[W]|[X][e]|[Y][b]?|[Z][nr]"
+                ),
+                collapse = ""
+            ),
         ")",
         "(?<Number>[0-9]*)"
     )
@@ -56,8 +61,28 @@ countElements <- function(x) {
         sbstr[!nchar(sbstr)] <- 1L
         sl <- seq_len(n)
         nm <- sbstr[sl]
-        setNames(as.integer(sbstr[n + sl]), nm)
+        r <- setNames(as.integer(sbstr[n + sl]), nm)
+        valid <- .isValidElementName(nm)
+
+        if (any(!valid)) {
+            warning(
+                "The following names are not valid and are dropped: ",
+                paste0(names(r)[!valid], collapse = ", ")
+            )
+            r <- r[valid]
+        }
+        r
     }, xx = x, rr = rx, SIMPLIFY = FALSE, USE.NAMES = TRUE)
+}
+
+#' Validate element names/heavy isotopes
+#'
+#' @param x `character`, element/heavy isotope names
+#' @return `logical`, `TRUE` for valid name, `FALSE` otherwise
+#'
+#' @noRd
+.isValidElementName <- function(x) {
+    x %in% names(.ISOTOPES)
 }
 
 #' @title Create chemical formula from a named vector

--- a/R/chemFormula.R
+++ b/R/chemFormula.R
@@ -291,12 +291,12 @@ calculateMass <- function(x) {
     if (!is.list(x))
         stop("x must be either a character or a list with element counts.")
     vapply(x, function(z) {
-        elements <- names(z)
-        if (!all(elements %in% names(.MONOISOTOPES))) {
-            message("not for all elements a monoisotopic mass is found")
+        isotopes <- names(z)
+        if (!length(z) || !all(isotopes %in% names(.ISOTOPES))) {
+            message("not for all isotopes a mass is found")
             return(NA_real_)
         }
-        sum(z * .MONOISOTOPES[elements])
+        sum(z * .ISOTOPES[isotopes])
         ## mass <- 0.0
         ## for (atom in elements) {
         ##     atom_mass <- .MONOISOTOPES[atom]

--- a/R/chemFormula.R
+++ b/R/chemFormula.R
@@ -117,7 +117,10 @@ pasteElements <- function(x) {
     enms <- .sort_elements(names(x))
     y <- as.character(x[enms])
     y[y == "1"] <- ""
-    paste0(enms, y, collapse = "")
+    y <- paste0(enms, y)
+    ## brackets for heavy isotopes
+    y <- gsub("^([0-9]+[A-z]+[0-9]*)", "[\\1]", y)
+    paste0(y, collapse = "")
 }
 
 #' Sort elements starting with organic elements, according to the Hill notation
@@ -130,9 +133,7 @@ pasteElements <- function(x) {
 #' @examples
 #' .sort_elements(c("H", "O", "S", "P", "C", "N", "Na", "Fe"))
 .sort_elements <- function(x) {
-    org <- c("C", "H", "N", "O", "S", "P")
-    y <- c(org, sort(x[!x %in% org]))
-    x[match(y, x, nomatch = 0L)]
+    x[match(names(.ISOTOPES), x, nomatch = 0L)]
 }
 
 #' @title Standardize a chemical formula

--- a/man/calculateMass.Rd
+++ b/man/calculateMass.Rd
@@ -21,6 +21,7 @@ calculateMass(x)
 calculateMass("C6H12O6")
 calculateMass("NH3")
 calculateMass(c("C6H12O6", "NH3"))
+calculateMass(c("C6H12O6", "[13C3]C3H12O6"))
 }
 \author{
 Michael Witting

--- a/tests/testthat/test_chemFormula.R
+++ b/tests/testthat/test_chemFormula.R
@@ -139,4 +139,5 @@ test_that("correct calculation of masses", {
                  180.0634)
     expect_equal(unname(round(calculateMass(countElements("C11H12N2O2")), 4)),
                  204.0899)
+    expect_gt(calculateMass("[13C]C5H12O6"), calculateMass("C6H12O6"))
 })

--- a/tests/testthat/test_chemFormula.R
+++ b/tests/testthat/test_chemFormula.R
@@ -123,8 +123,12 @@ test_that("correct calculation of masses", {
     expect_equal(unname(round(calculateMass("C6H12O6"), 4)), 180.0634)
     expect_equal(unname(round(calculateMass("C11H12N2O2"), 4)), 204.0899)
     expect_equal(
-        round(unname(calculateMass(c("C6H12O6", "C11H12N2O2", "blabla"))), 4),
-        c(180.0634, 204.0899, NA))
+        unname(suppressWarnings(
+                calculateMass(c("C6H12O6", "C11H12N2O2", "blabla"))
+        )),
+        c(180.0634, 204.0899, NA),
+        tolerance = 1e-5
+    )
 
     ## calculation of exact masses from named numeric vector
     expect_equal(unname(round(calculateMass(countElements("C6H12O6")), 4)),

--- a/tests/testthat/test_chemFormula.R
+++ b/tests/testthat/test_chemFormula.R
@@ -42,6 +42,8 @@ test_that("countElements", {
         countElements(c("C6H12O6", "H2O")),
         list(C6H12O6 = c(C = 6L, H = 12L, O = 6L), H2O = c(H = 2L, O = 1L))
     )
+
+    ## heavy isotopes
     expect_identical(
         countElements(c("[13C3]C3H12O6", "[2H2]O")),
         list(
@@ -49,6 +51,8 @@ test_that("countElements", {
             "[2H2]O" = c("2H" = 2L, O = 1L)
         )
     )
+    expect_warning(r <- countElements("[45C6][10H12]O6"), "not valid")
+    expect_identical(r, list("[45C6][10H12]O6" = c(O = 6L)))
 })
 
 test_that(".isValidElementName",

--- a/tests/testthat/test_chemFormula.R
+++ b/tests/testthat/test_chemFormula.R
@@ -69,12 +69,16 @@ test_that("pasteElements", {
         pasteElements(list(c(C = 6, O = 6, H = 12), c(H = 2, O = 1))),
         c("C6H12O6", "H2O")
     )
+    expect_identical(pasteElements(c(C = 1, "13C" = 2)), "[13C2]C")
 })
 
 test_that(".sort_elements", {
     expect_identical(
         .sort_elements(c("H", "O", "S", "P", "C", "N", "Na", "Fe")),
         c("C", "H", "N", "O", "S", "P", "Fe", "Na")
+    )
+    expect_identical(
+        .sort_elements(c("H", "C", "13C", "2H")), c("13C", "C", "2H", "H")
     )
 })
 

--- a/tests/testthat/test_chemFormula.R
+++ b/tests/testthat/test_chemFormula.R
@@ -51,6 +51,13 @@ test_that("countElements", {
     )
 })
 
+test_that(".isValidElementName",
+    expect_equal(
+        .isValidElementName(c("13C", "45C", "2H", "10H")),
+        c(TRUE, FALSE, TRUE, FALSE)
+    )
+)
+
 test_that("pasteElements", {
     expect_identical(pasteElements(c(C = 6, O = 6, H = 12)), "C6H12O6")
     expect_identical(pasteElements(c(C = 1, O = 1, H = 3)), "CH3O")

--- a/tests/testthat/test_chemFormula.R
+++ b/tests/testthat/test_chemFormula.R
@@ -42,6 +42,13 @@ test_that("countElements", {
         countElements(c("C6H12O6", "H2O")),
         list(C6H12O6 = c(C = 6L, H = 12L, O = 6L), H2O = c(H = 2L, O = 1L))
     )
+    expect_identical(
+        countElements(c("[13C3]C3H12O6", "[2H2]O")),
+        list(
+            "[13C3]C3H12O6" = c("13C" = 3L, C = 3L, H = 12L, O = 6L),
+            "[2H2]O" = c("2H" = 2L, O = 1L)
+        )
+    )
 })
 
 test_that("pasteElements", {

--- a/tests/testthat/test_zzz.R
+++ b/tests/testthat/test_zzz.R
@@ -12,6 +12,6 @@ test_that(".load_adducts works", {
 })
 
 test_that(".load_isotopes works", {
-    mono <- .load_isotopes()
-    expect_true(length(mono) > 0)
+    iso <- .load_isotopes()
+    expect_equal(iso[c("H", "2H")], c(H = 1.007825032, "2H" = 2.014101778))
 })


### PR DESCRIPTION
This PR implements support for heavy isotopes as requested in #53 (resolves #53). Unfortunately it increase the complexity of some functions namely `.load_isotopes()` (added some additional sorting steps), `countElements()` (test for valid isotopes/element names) and `.pasteElements` (additional `gsub` call to surround heavy isotopes with brackets).

``` r
library("MetaboCoreUtils")

countElements(c("C6H12O6", "[13C3]C3H12O6"))
#> $C6H12O6
#>  C  H  O 
#>  6 12  6 
#> 
#> $`[13C3]C3H12O6`
#> 13C   C   H   O 
#>   3   3  12   6
standardizeFormula("O6[13C3]H12C3")
#>   O6[13C3]H12C3 
#> "[13C3]C3H12O6"
calculateMass(c("C6H12O6", "[13C3]C3H12O6"))
#>       C6H12O6 [13C3]C3H12O6 
#>      180.0634      183.0735
```

<sup>Created on 2022-03-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

EDIT: All isotopes listed in [isotope_definition.txt](https://github.com/rformassspectrometry/MetaboCoreUtils/blob/master/inst/isotopes/isotope_definition.txt) are supported.