### PR TITLE
refactor: drop elements with zero counts (fix #57)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MetaboCoreUtils
 Title: Core Utils for Metabolomics Data
-Version: 1.5.1
+Version: 1.5.2
 Description: MetaboCoreUtils defines metabolomics-related core functionality
     provided as low-level functions to allow a data structure-independent usage
     across various R packages. This includes functions to calculate between ion

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # MetaboCoreUtils 1.5
 
+## MetaboCoreUtils 1.5.2
+
+- `substractElements` drops elements with zero counts (issue
+  [#57](https://github.com/rformassspectrometry/MetaboCoreUtils/issues/55)).
+
 ## MetaboCoreUtils 1.5.1
 
 - Add functions `formula2mz`, `adductFormula` and `multiplyElements` (issue

--- a/R/chemFormula.R
+++ b/R/chemFormula.R
@@ -227,10 +227,11 @@ subtractElements <- function(x, y) {
     unlist(mapply(
         FUN = function(xx, yy) {
             s <- .sum_elements(c(xx, -yy))
+
             if (any(s < 0))
                 NA_character_
             else
-                .pasteElements(s)
+                .pasteElements(s[s > 0])
         },
         xx = countElements(x), yy = countElements(y),
         SIMPLIFY = FALSE, USE.NAMES = FALSE

--- a/tests/testthat/test_chemFormula.R
+++ b/tests/testthat/test_chemFormula.R
@@ -11,6 +11,8 @@ test_that("correct formula mathematics", {
     ## check formula subtraction (single formulae)
     expect_identical(subtractElements("C6H12O6", "H2O"), "C6H10O5")
     expect_identical(subtractElements("C6H12O6", "NH3"), NA_character_)
+    expect_identical(subtractElements("C6H12O6", "C6"), "H12O6")
+    expect_identical(subtractElements("C6H12O6", "C6H12O6"), "")
 
     ## check formula subtration (multiple formulae)
     expect_identical(


### PR DESCRIPTION
This PR closes #57.

Now `substractElements` drops all zero counts but doesn't return `NA` if all counts are zero but `""`. IMHO an invalid subtraction  should return something different than a valid subtraction.