### PR TITLE
feat: accept NA in countElements; see #61

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MetaboCoreUtils
 Title: Core Utils for Metabolomics Data
-Version: 1.7.0
+Version: 1.9.1
 Description: MetaboCoreUtils defines metabolomics-related core functionality
     provided as low-level functions to allow a data structure-independent usage
     across various R packages. This includes functions to calculate between ion

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# MetaboCoreUtils 1.9
+
+## MetaboCoreUtils 1.9.1
+
+- `countElements`, `subtractElements` and `addElements` returns `NA` if
+  an input arguments is `NA`
+  (issue [#61](https://github.com/rformassspectrometry/MetaboCoreUtils/issues/61),
+  PR [#62](https://github.com/rformassspectrometry/MetaboCoreUtils/pull/62)).
+
 # MetaboCoreUtils 1.5
 
 ## MetaboCoreUtils 1.5.2

--- a/R/chemFormula.R
+++ b/R/chemFormula.R
@@ -50,10 +50,15 @@ countElements <- function(x) {
         ")",
         "(?<Number>[0-9]*)"
     )
+
     rx <- gregexpr(pattern = element_pattern, text = x, perl = TRUE)
 
     mapply(function(xx, rr) {
         n <- length(rr)
+
+        if (is.na(xx))
+            return (NA_integer_)
+
         start <- attr(rr, "capture.start")
         end <- start + attr(rr, "capture.length") - 1L
         sbstr <- substring(xx, start, end)
@@ -170,7 +175,7 @@ standardizeFormula <- function(x) {
 .sum_elements <- function(x) {
     if (!is.character(names(x)))
         stop("element names missing")
-    unlist(lapply(split(x, names(x)), sum))
+    unlist(lapply(split(x, names(x)), sum, na.rm = TRUE))
 }
 
 #' @title Check if one formula is contained in another
@@ -290,13 +295,13 @@ addElements <- function(x, y) {
 #' multiplyElements("H2O", 3)
 #'
 #' multiplyElements(c("C6H12O6", "Na", "CH4O"), 2)
-#' 
+#'
 multiplyElements <- function(x, k){
     if (length(k) != 1) stop("k must have length one (1)")
     if (!is.numeric(k) | k <= 0) stop("k must be a positive integer")
     vapply(countElements(x), function(xx){.pasteElements(xx * k)},
            FUN.VALUE = character(1),
-           USE.NAMES = FALSE)  
+           USE.NAMES = FALSE)
 }
 
 #' @title Calculate exact mass

--- a/R/chemFormula.R
+++ b/R/chemFormula.R
@@ -57,7 +57,7 @@ countElements <- function(x) {
         n <- length(rr)
 
         if (is.na(xx))
-            return (NA_integer_)
+            return(NA_integer_)
 
         start <- attr(rr, "capture.start")
         end <- start + attr(rr, "capture.length") - 1L
@@ -117,6 +117,8 @@ pasteElements <- function(x) {
     unlist(lapply(x, .pasteElements))
 }
 .pasteElements <- function(x) {
+    if (anyNA(x))
+        return(NA_character_)
     if (!is.character(names(x)))
         stop("element names missing")
     enms <- .sort_elements(names(x))
@@ -175,7 +177,9 @@ standardizeFormula <- function(x) {
 .sum_elements <- function(x) {
     if (!is.character(names(x)))
         stop("element names missing")
-    unlist(lapply(split(x, names(x)), sum, na.rm = TRUE))
+    if (anyNA(x))
+        return(NA_integer_)
+    unlist(lapply(split(x, names(x)), sum))
 }
 
 #' @title Check if one formula is contained in another
@@ -233,10 +237,10 @@ subtractElements <- function(x, y) {
         FUN = function(xx, yy) {
             s <- .sum_elements(c(xx, -yy))
 
-            if (any(s < 0))
-                NA_character_
-            else
+            if (isTRUE(all(s >= 0)))
                 .pasteElements(s[s > 0])
+            else
+                NA_character_
         },
         xx = countElements(x), yy = countElements(y),
         SIMPLIFY = FALSE, USE.NAMES = FALSE
@@ -296,7 +300,7 @@ addElements <- function(x, y) {
 #'
 #' multiplyElements(c("C6H12O6", "Na", "CH4O"), 2)
 #'
-multiplyElements <- function(x, k){
+multiplyElements <- function(x, k) {
     if (length(k) != 1) stop("k must have length one (1)")
     if (!is.numeric(k) | k <= 0) stop("k must be a positive integer")
     vapply(countElements(x), function(xx){.pasteElements(xx * k)},

--- a/tests/testthat/test_chemFormula.R
+++ b/tests/testthat/test_chemFormula.R
@@ -44,6 +44,15 @@ test_that("countElements", {
         countElements(c("C6H12O6", "H2O")),
         list(C6H12O6 = c(C = 6L, H = 12L, O = 6L), H2O = c(H = 2L, O = 1L))
     )
+    expect_identical(
+        countElements(c("C6H12O6", NA, "H2O")),
+        structure(
+            list(
+                c(C = 6L, H = 12L, O = 6L), NULL,
+                c(H = 2L, O = 1L)
+            ), names = c("C6H12O6", NA, "H2O")
+        )
+    )
 
     ## heavy isotopes
     expect_identical(
@@ -102,6 +111,7 @@ test_that("containsElements", {
 
 test_that("subtractElements", {
     expect_identical(subtractElements("C6H12O6", "H2O"), "C6H10O5")
+    expect_identical(subtractElements("C6H12O6", NA), "C6H12O6")
     expect_identical(
         subtractElements(c("C6H12O6", "C6H12O6"), c("H2O", "NH3")),
         c("C6H10O5", NA_character_)
@@ -114,6 +124,7 @@ test_that("subtractElements", {
 
 test_that("addElements", {
     expect_identical(addElements("C6H12O6", "H2O"), "C6H14O7")
+    expect_identical(addElements("C6H12O6", NA), "C6H12O6")
     expect_identical(
         addElements(c("C6H12O6", "C6H12O6"), c("H2O", "NH3")),
         c("C6H14O7", "C6H15NO6")
@@ -129,11 +140,11 @@ test_that("multiplyElements", {
     expect_equivalent(multiplyElements("C6H12O6", 2), "C12H24O12")
     expect_equivalent(multiplyElements(c("C6H12O6", "Na", "CH4O"), 2),
                       c("C12H24O12", "Na2", "C2H8O2"))
-    
+
     expect_error(multiplyElements("H2O", -10))
     expect_error(multiplyElements("H2O", 0))
     expect_error(multiplyElements("H2O", c(2,3)))
-    
+
 })
 
 test_that("correct calculation of masses", {

--- a/tests/testthat/test_chemFormula.R
+++ b/tests/testthat/test_chemFormula.R
@@ -48,7 +48,7 @@ test_that("countElements", {
         countElements(c("C6H12O6", NA, "H2O")),
         structure(
             list(
-                c(C = 6L, H = 12L, O = 6L), NULL,
+                c(C = 6L, H = 12L, O = 6L), NA_integer_,
                 c(H = 2L, O = 1L)
             ), names = c("C6H12O6", NA, "H2O")
         )
@@ -103,6 +103,7 @@ test_that("standardizeFormula", {
 test_that("containsElements", {
     expect_true(containsElements("C6H12O6", "H2O"))
     expect_false(containsElements("C6H12O6", "NH3"))
+    expect_identical(containsElements("C6H12O6", NA), NA)
     expect_identical(
         containsElements("C6H12O6", c("H2O", "NH3")),
         c(TRUE, FALSE)
@@ -111,7 +112,7 @@ test_that("containsElements", {
 
 test_that("subtractElements", {
     expect_identical(subtractElements("C6H12O6", "H2O"), "C6H10O5")
-    expect_identical(subtractElements("C6H12O6", NA), "C6H12O6")
+    expect_identical(subtractElements("C6H12O6", NA), NA_character_)
     expect_identical(
         subtractElements(c("C6H12O6", "C6H12O6"), c("H2O", "NH3")),
         c("C6H10O5", NA_character_)
@@ -124,7 +125,7 @@ test_that("subtractElements", {
 
 test_that("addElements", {
     expect_identical(addElements("C6H12O6", "H2O"), "C6H14O7")
-    expect_identical(addElements("C6H12O6", NA), "C6H12O6")
+    expect_identical(addElements("C6H12O6", NA), NA_character_)
     expect_identical(
         addElements(c("C6H12O6", "C6H12O6"), c("H2O", "NH3")),
         c("C6H14O7", "C6H15NO6")


### PR DESCRIPTION
This PR allows `NA`s in `subtractElements` and `addElements` by handling `NA`s in `countElements` (problem described in #61 )

`subtractElements("H2O", NA)` returns `"H2O"`. Or should it return `NA`?

Unfortunately it introduce a strange behaviour for `containsElements`:

```r
containsElements("H2O", NA)
# [1] TRUE
```

IMHO `containsElements("H2O", NA)` should return `FALSE` or `NA`.

@jorainer, @michaelwitting any suggestion for the expected behaviour?
