### PR TITLE
refactor: countElements returns NA if an element is invalid instead of dropping it

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MetaboCoreUtils
 Title: Core Utils for Metabolomics Data
-Version: 1.9.1
+Version: 1.9.2
 Description: MetaboCoreUtils defines metabolomics-related core functionality
     provided as low-level functions to allow a data structure-independent usage
     across various R packages. This includes functions to calculate between ion

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # MetaboCoreUtils 1.9
 
+## MetaboCoreUtils 1.9.2
+
+- `countElements` returns `NA` for invalid elements instead of silently
+  dropping them (
+  PR [#65](https://github.com/rformassspectrometry/MetaboCoreUtils/pull/65)).
+
 ## MetaboCoreUtils 1.9.1
 
 - `countElements`, `subtractElements` and `addElements` returns `NA` if

--- a/R/adducts.R
+++ b/R/adducts.R
@@ -228,13 +228,11 @@ adductFormula <- function(formulas, adduct = "[M+H]+", standardize = TRUE) {
     if (standardize) {
         formulas <- lapply(formulas, standardizeFormula)
         if (all(formulas == "")) stop("No valid formulas")
-        formulas <- formulas[formulas != ""]
+        formulas <- formulas[!is.na(formulas)]
     }
     ionMatrix <- lapply(formulas, function(formula, adduct) {
         formulaAdduct <- apply(adduct, 1, function(x) {
             current_f <- formula
-
-            if (is.null(current_f)) return(NULL)
 
             multiplicity <- round(as.numeric(x["mass_multi"]) *
                                       as.numeric(x["charge"]))
@@ -267,7 +265,7 @@ adductFormula <- function(formulas, adduct = "[M+H]+", standardize = TRUE) {
         return(formulaAdduct)
     }, adduct = adduct)
     ionMatrix <- do.call(rbind, ionMatrix)
-    rownames(ionMatrix) <- formulas[as.logical(lengths(formulas))]
+    rownames(ionMatrix) <- formulas
     colnames(ionMatrix) <- rownames(adduct)
     return(ionMatrix)
 }

--- a/R/adducts.R
+++ b/R/adducts.R
@@ -233,6 +233,9 @@ adductFormula <- function(formulas, adduct = "[M+H]+", standardize = TRUE) {
     ionMatrix <- lapply(formulas, function(formula, adduct) {
         formulaAdduct <- apply(adduct, 1, function(x) {
             current_f <- formula
+
+            if (is.null(current_f)) return(NULL)
+
             multiplicity <- round(as.numeric(x["mass_multi"]) *
                                       as.numeric(x["charge"]))
             if (multiplicity != 1) {
@@ -264,7 +267,7 @@ adductFormula <- function(formulas, adduct = "[M+H]+", standardize = TRUE) {
         return(formulaAdduct)
     }, adduct = adduct)
     ionMatrix <- do.call(rbind, ionMatrix)
-    rownames(ionMatrix) <- formulas
+    rownames(ionMatrix) <- formulas[as.logical(lengths(formulas))]
     colnames(ionMatrix) <- rownames(adduct)
     return(ionMatrix)
 }

--- a/R/chemFormula.R
+++ b/R/chemFormula.R
@@ -25,25 +25,25 @@ countElements <- function(x) {
         "(?<Element>",
             paste0("[0-9]*",
                 c(
-                    "[A][cglmrstu]|",
-                    "[B][aehikr]?|",
-                    "[C][adeflmnorsu]?|",
-                    "[D][bsy]|",
-                    "[E][rsu]|",
-                    "[F][elmr]?|",
-                    "[G][ade]|",
-                    "[H][efgos]?|",
-                    "[I][nr]?|",
-                    "[K][r]?|",
-                    "[L][airuv]|",
-                    "[M][cdgnot]|",
-                    "[N][abdehiop]?|",
-                    "[O][gs]?|",
-                    "[P][abdmortu]?|",
-                    "[R][abefghnu]|",
-                    "[S][bcegimnr]?|",
-                    "[T][abcehilms]|",
-                    "[U]|[V]|[W]|[X][e]|[Y][b]?|[Z][nr]"
+                    "A[cglmrstu]|",
+                    "B[aehikr]?|",
+                    "C[adeflmnorsu]?|",
+                    "D[bsy]|",
+                    "E[rsu]|",
+                    "F[elmr]?|",
+                    "G[ade]|",
+                    "H[efgos]?|",
+                    "I[nr]?|",
+                    "Kr?|",
+                    "L[airuv]|",
+                    "M[cdgnot]|",
+                    "N[abdehiop]?|",
+                    "O[gs]?|",
+                    "P[abdmortu]?|",
+                    "R[abefghnu]|",
+                    "S[bcegimnr]?|",
+                    "T[abcehilms]|",
+                    "U|V|W|Xe|Yb?|Z[nr]"
                 ),
                 collapse = ""
             ),
@@ -58,6 +58,10 @@ countElements <- function(x) {
 
         if (is.na(xx))
             return(NA_integer_)
+        if (sum(attr(rr, "match.length")) != nchar(gsub("\\[|\\]", "", xx))) {
+            warning("The given formula '", xx, "' contains invalid symbols.")
+            return(NA_integer_)
+        }
 
         start <- attr(rr, "capture.start")
         end <- start + attr(rr, "capture.length") - 1L
@@ -175,10 +179,10 @@ standardizeFormula <- function(x) {
 #' @examples
 #' .sum_elements(c(H = 6, C = 3, O = 6, C = 3, H = 6))
 .sum_elements <- function(x) {
-    if (!is.character(names(x)))
-        stop("element names missing")
     if (anyNA(x))
         return(NA_integer_)
+    if (!is.character(names(x)))
+        stop("element names missing")
     unlist(lapply(split(x, names(x)), sum))
 }
 
@@ -336,7 +340,9 @@ calculateMass <- function(x) {
         stop("x must be either a character or a list with element counts.")
     vapply(x, function(z) {
         isotopes <- names(z)
-        if (!length(z) || !all(isotopes %in% names(.ISOTOPES))) {
+        if (!length(z) ||
+            is.null(isotopes) ||
+            !all(isotopes %in% names(.ISOTOPES))) {
             message("not for all isotopes a mass is found")
             return(NA_real_)
         }

--- a/tests/testthat/test_chemFormula.R
+++ b/tests/testthat/test_chemFormula.R
@@ -53,6 +53,15 @@ test_that("countElements", {
             ), names = c("C6H12O6", NA, "H2O")
         )
     )
+    expect_warning(countElements("Foo"), "invalid")
+    expect_identical(
+        suppressWarnings(countElements(c("C6H12O6", "Foo", "H2O"))),
+        list(
+            "C6H12O6" = c(C = 6L, H = 12L, O = 6L),
+            Foo = NA_integer_,
+            "H2O" = c(H = 2L, O = 1L)
+        )
+    )
 
     ## heavy isotopes
     expect_identical(


### PR DESCRIPTION
This PR propose a solution to #64 . 

I had to touch `.sum_elements` (change order of tests), `calculateMass` (test for `NULL`) and `adductFormula` (drop invalid formulas silently) to keep the current behaviour (and pass all unit tests).

```r
countElements("C1Fo")

# $C1Fo
# [1] NA
# 
# Warning message:
# In (function (xx, rr)  : The given formula 'C1Fo' contains invalid symbols
```

Unfortunately we lose the position information (e.g. pos 3 contains "Fo").

BTW: I removed unnecessary `[` and `]` in the regexp.
