### PR TITLE
containElements returns TRUE for invalid elements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MetaboCoreUtils
 Title: Core Utils for Metabolomics Data
-Version: 1.9.2
+Version: 1.9.3
 Description: MetaboCoreUtils defines metabolomics-related core functionality
     provided as low-level functions to allow a data structure-independent usage
     across various R packages. This includes functions to calculate between ion

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # MetaboCoreUtils 1.9
 
+## MetaboCoreUtils 1.9.3
+
+- `containsElements` returns `NA` for `NA` and `FALSE` for invalid elements;
+  see issue
+  [#63](https://github.com/rformassspectrometry/MetaboCoreUtils/issues/63).
+
 ## MetaboCoreUtils 1.9.2
 
 - `countElements` returns `NA` for invalid elements instead of silently

--- a/R/chemFormula.R
+++ b/R/chemFormula.R
@@ -208,11 +208,16 @@ standardizeFormula <- function(x) {
 #' containsElements("C6H12O6", "H2O")
 #' containsElements("C6H12O6", "NH3")
 containsElements <- function(x, y) {
-    mapply(
+    r <- mapply(
         FUN = function(xx, yy)all(.sum_elements(c(xx, -yy)) >= 0),
         xx = countElements(x), yy = countElements(y),
         SIMPLIFY = TRUE, USE.NAMES = FALSE
     )
+    ## return FALSE for invalid elements
+    r[is.na(r)] <- FALSE
+    ## return NA for NA as input
+    r[is.na(x) | is.na(y)] <- NA
+    r
 }
 
 #' @title subtract two chemical formula

--- a/tests/testthat/test_chemFormula.R
+++ b/tests/testthat/test_chemFormula.R
@@ -113,8 +113,8 @@ test_that("containsElements", {
     expect_true(containsElements("C6H12O6", "H2O"))
     expect_false(containsElements("C6H12O6", "NH3"))
     expect_identical(containsElements("C6H12O6", NA), NA)
-    expect_false(containsElements("C6H12O6", "Z"))
-    expect_false(containsElements("C6H12O6", ""))
+    expect_false(suppressWarnings(containsElements("C6H12O6", "Z")))
+    expect_false(suppressWarnings(containsElements("C6H12O6", "")))
     expect_identical(
         containsElements("C6H12O6", c("H2O", "NH3")),
         c(TRUE, FALSE)

--- a/tests/testthat/test_chemFormula.R
+++ b/tests/testthat/test_chemFormula.R
@@ -113,6 +113,8 @@ test_that("containsElements", {
     expect_true(containsElements("C6H12O6", "H2O"))
     expect_false(containsElements("C6H12O6", "NH3"))
     expect_identical(containsElements("C6H12O6", NA), NA)
+    expect_false(containsElements("C6H12O6", "Z"))
+    expect_false(containsElements("C6H12O6", ""))
     expect_identical(
         containsElements("C6H12O6", c("H2O", "NH3")),
         c(TRUE, FALSE)


### PR DESCRIPTION
This PR fixes #63.

`containsElements` now returns `NA` for `NA`, and `FALSE` for invalid elements (like `"Z"`).

I am not sure about the return value for invalid elements. IMHO `NA` would be fine (in that case this PR is superfluous).

If this PR is needed, we could argue about the use of `suppressWarnings` inside `containsElements`. `containsElements("H2O", "Z")` will return `FALSE` and produce a warning about "Z". (If we ignore this PR the result would be `NA` anyway).